### PR TITLE
disables forking (in chainId 31337)

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -37,9 +37,9 @@ module.exports = {
     networks: {
         hardhat: {
             chainId: 31337,
-            forking: {
+            /*forking: {
                 url: MAINNET_RPC_URL,
-            },
+            },*/
         },
         goerli: {
             url: GOERLI_RPC_URL,


### PR DESCRIPTION
Hardhat was currently forking the blockchain from MAINNET_RPC_URL (Ethereum?) when running on a local network (i.e. 31337), commenting it fixes the problem.